### PR TITLE
Get trace_id, span_id from SpanContext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,27 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.17.5)
 project(opentelemetry-c VERSION 1.1.1 LANGUAGES C CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
 include(CTest)
+include(GNUInstallDirs)
+include(CMakeFindDependencyMacro)
 
 find_package(opentelemetry-cpp REQUIRED)
-
-include(GNUInstallDirs)
-#include(CMakeDependentOption)
 
 add_library(opentelemetry-c SHARED
 	src/common.cpp
 	src/exporter_jaeger_trace.cpp
-	#src/exporter_otlp_grpc.cpp
 	src/exporter_otlp_http.cpp
 )
 target_include_directories(opentelemetry-c PUBLIC include)
 target_compile_definitions(opentelemetry-c PRIVATE -DENABLE_ASYNC_EXPORT)
 set_target_properties(opentelemetry-c PROPERTIES POSITION_INDEPENDET_CODE ON VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-#set_target_properties(opentelemetry-c PROPERTIES PUBLIC_HEADER "include/opentelemetry-c/*.h")
 target_link_libraries(opentelemetry-c PUBLIC
-	opentelemetry_common
-	opentelemetry_trace
-	opentelemetry_exporter_jaeger_trace
-	#opentelemetry_exporter_otlp_grpc
-	opentelemetry_exporter_otlp_http
+	opentelemetry-cpp::opentelemetry-cpp
+	opentelemetry-cpp::opentelemetry_common
+	opentelemetry-cpp::opentelemetry_trace
+	opentelemetry-cpp::opentelemetry_exporter_jaeger_trace
+	opentelemetry-cpp::opentelemetry_exporter_otlp_http
 )
-
-include(GNUInstallDirs)
 
 install(
 	TARGETS opentelemetry-c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.17.5)
-project(opentelemetry-c VERSION 1.1.1 LANGUAGES C CXX)
+project(opentelemetry-c VERSION 1.1.2 LANGUAGES C CXX)
 
 include(CTest)
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # OpenTelemetry C
 
 An OpenTelemetry C wrapper for [OpenTelemetry C++ library](https://github.com/open-telemetry/opentelemetry-cpp).
+
+## Requirements
+
+- conan2
+- cmake at least 3.17.5
+- opentelemetry-cpp 1.9.1
+
+## Build
+
+```
+$ git clone https://github.com/sorc1/opentelemetry-c
+$ cd opentelemetry-c
+$ conan install . --build=missing -of=build
+$ cd build
+$ cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+$ make
+```

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+opentelemetry-cpp/1.9.1
+
+[generators]
+CMakeDeps
+CMakeToolchain
+

--- a/include/opentelemetry-c/common.h
+++ b/include/opentelemetry-c/common.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/types.h>
 #include <time.h>
 
 #ifdef  __cplusplus
@@ -221,13 +222,15 @@ opentelemetry_span *opentelemetry_span_start2(opentelemetry_tracer *tracer, cons
 opentelemetry_trace_state *opentelemetry_span_trace_state_get(opentelemetry_span *span);
 void opentelemetry_span_set_attribute(opentelemetry_span *span, const opentelemetry_attribute *attribute);
 void opentelemetry_span_add_event(
-	opentelemetry_span *span, const opentelemetry_string *name,	const struct timespec *tp,
+	opentelemetry_span *span, const opentelemetry_string *name, const struct timespec *tp,
 	const opentelemetry_attribute *attributes, size_t nattributes);
 typedef int (*opentelemetry_header_each)(const char *name, size_t name_len, const char *value, size_t value_len, void *arg);
 int opentelemetry_span_headers_get(opentelemetry_span *span, opentelemetry_header_each header_each, void *header_each_arg);
 typedef const char *(*opentelemetry_header_value)(const char *name, size_t name_len, size_t *value_len, void *arg);
 opentelemetry_span *opentelemetry_span_start_headers(opentelemetry_tracer *tracer, const opentelemetry_string *name, opentelemetry_header_value header_value, void *header_value_arg);
 void opentelemetry_span_finish(opentelemetry_span *span);
+ssize_t opentelemetry_span_get_trace_id(opentelemetry_span* span, char* buffer, size_t buffer_size);
+ssize_t opentelemetry_span_get_span_id(opentelemetry_span* span, char* buffer, size_t buffer_size);
 
 enum opentelemetry_log_level {
 	OPENTELEMETRY_LOG_LEVEL_ERROR = 0,

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -101,6 +101,14 @@ int test_span(opentelemetry_processor *processor) {
 		tracer,  &(opentelemetry_string)OPENTELEMETRY_CSTR("root"), NULL);
 	if (span == NULL)
 		return 1;
+
+	char trace_id[32];
+	if (opentelemetry_span_get_trace_id(span, trace_id, 32) != 32)
+		return 1;
+	char span_id[16];
+	if (opentelemetry_span_get_span_id(span, span_id, 16) != 16)
+		return 1;
+
 	double dvalues1[] = {4.4, 5.5, 6.6};
 	double dvalues2[] = {7.7, 8.8, 9.9};
 	opentelemetry_attribute span_attrs[] = {


### PR DESCRIPTION
This PR adds two functions to get trace_id and span_id from SpanContext

Purpose:
There is need to create a SpanLink between to independent spans. To achieve this goal we need to store trace_id and span_id and use them on creating new span

both functions may return:
- -1: if Span or SpanContext are invalid
- positive number: the number of bytes copied into buffer. If buffer for id is too small, will return a number of bytes required for buffer (32 for trace_id and 16 for span_id)